### PR TITLE
POPS-875 Create catalog-info.yaml for ownership of Platform-Ops repo's

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -19,5 +19,5 @@ metadata:
 
 spec:
   type: other
-  owner: tradeshift/orphan
+  owner: platform-ops
   lifecycle: experimental


### PR DESCRIPTION
We need to update the catalog-info.yml to show the right owners of the repo: platform-ops